### PR TITLE
Change margin top from A4260

### DIFF
--- a/templates/A4260.json
+++ b/templates/A4260.json
@@ -8,7 +8,7 @@
             "210.0",
             "297.0"
         ],
-        "margin-top": "15.2",
+        "margin-top": "12.2",
         "margin-left": "7.2",
         "margin-right": "7.2",
         "margin-bottom": "15.2",


### PR DESCRIPTION
Esse tamanho do margin-top funcionou melhor. Do tamanho default sempre quebra as últimas 3 etiquetas da página. Se quiser dar uma olhada na minha aplicação https://github.com/puppe1990/pimaco-print-tags que estou usando a tua lib.